### PR TITLE
Modified directory creation to make it compatible with Linux systems.

### DIFF
--- a/tools/utilities/pipeline_functions/generateHTMLReport.m
+++ b/tools/utilities/pipeline_functions/generateHTMLReport.m
@@ -5,7 +5,7 @@ function generateHTMLReport(modelName)
   load(fullfile('Code','logsPath.mat'),'path');
   parentFolder = fullfile('Design', modelName, 'pipeline', 'analyze');
   if ~exist(fullfile(parentFolder, 'package'), 'dir')
-      mkdir([parentFolder, '\package']);
+      mkdir(fullfile(parentFolder, 'package'));
   end
   xslt(fullfile(path,'logs',[modelName 'Report.xml']), 'report.xsl', fullfile('Design',modelName,'pipeline','analyze', 'package', [modelName 'SummaryReport.html']));
 end

--- a/tools/utilities/pipeline_functions/modelAdvisorAction.m
+++ b/tools/utilities/pipeline_functions/modelAdvisorAction.m
@@ -64,7 +64,7 @@ classdef modelAdvisorAction
             %creates specific subfolder for report
             parentFolder = fullfile(obj.prjRootFolder, 'Design', obj.modelName, 'pipeline', 'analyze');
             if ~exist(fullfile(parentFolder, 'verify'), 'dir')
-                mkdir([parentFolder, '\verify']);
+                mkdir(fullfile(parentFolder, 'verify'));
             end
             obj.rptPath = fullfile(obj.prjRootFolder, 'Design', obj.modelName, 'pipeline', 'analyze', 'verify');
             

--- a/tools/utilities/pipeline_functions/modelBuildAction.m
+++ b/tools/utilities/pipeline_functions/modelBuildAction.m
@@ -55,7 +55,7 @@ classdef modelBuildAction
             srcReportPath = fullfile(obj.cfg.CodeGenFolder,[obj.modelName '_ert_rtw'], 'html');
             parentFolder = fullfile(char(obj.prj.RootFolder), 'Design', obj.modelName, 'pipeline', 'analyze');
             if ~exist(fullfile(parentFolder, 'build'), 'dir')
-                mkdir([parentFolder, '\build']);
+                mkdir(fullfile(parentFolder, 'build'));
             end
             destReportPath = fullfile(char(obj.prj.RootFolder), 'Design', obj.modelName, 'pipeline', 'analyze', 'build');
             

--- a/tools/utilities/pipeline_functions/modelTestsAction.m
+++ b/tools/utilities/pipeline_functions/modelTestsAction.m
@@ -65,7 +65,7 @@ classdef modelTestsAction
             obj.testRunner = TestRunner.withNoPlugins;
             parentFolder = fullfile(char(prj.RootFolder), 'Design', obj.modelName, 'pipeline', 'analyze');
             if ~exist(fullfile(parentFolder, 'testing'), 'dir')
-                mkdir([parentFolder, '\testing']);
+                mkdir(fullfile(parentFolder, 'testing'));
             end
             obj.resultsPath = fullfile(char(prj.RootFolder), 'Design', obj.modelName, 'pipeline', 'analyze', 'testing');
             delete(fullfile(obj.resultsPath, '*.tap'));

--- a/tools/utilities/setup/startUp.m
+++ b/tools/utilities/setup/startUp.m
@@ -35,7 +35,7 @@ path = './Code';
 save ./Code/logsPath path;
 load(fullfile('Code','logsPath.mat'),'path');
 if ~exist(fullfile(path, 'logs'), 'dir')
-    mkdir([path,'/logs']);
+    mkdir(fullfile(path, 'logs'));
 end
 
 pauseTime = 1.5;


### PR DESCRIPTION
Running this example on a Linux machine, folders with combined names like `analyse\package` are created, instead of a subfolder `package` inside the `analyse` folder.
Executing the CI pipeline thus leads to errors, as the expected subfolders can't be found.

Using MATLAB's `fullfile` function to generate the folder path should make the folder creation work as intended across all operating systems.